### PR TITLE
Add min os version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+/.idea/

--- a/app_info.gemspec
+++ b/app_info.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'CFPropertyList', '~> 2.3.4'
+  spec.add_dependency 'CFPropertyList', '~> 3.0.0'
   spec.add_dependency 'pngdefry', '~> 0.1.2'
   spec.add_dependency 'ruby_android', '~> 0.7.7'
   spec.add_dependency 'image_size', '~> 1.5.0'

--- a/app_info.gemspec
+++ b/app_info.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'CFPropertyList', '~> 3.0.0'
+  spec.add_dependency 'CFPropertyList', ['< 3.1.0', '>= 2.3.4']
   spec.add_dependency 'pngdefry', '~> 0.1.2'
   spec.add_dependency 'ruby_android', '~> 0.7.7'
   spec.add_dependency 'image_size', '~> 1.5.0'

--- a/lib/app_info/parser/ipa.rb
+++ b/lib/app_info/parser/ipa.rb
@@ -68,6 +68,13 @@ module AppInfo
         info.icons
       end
 
+      #
+      # Return the minimum OS version for the given application
+      #
+      def min_sdk_version
+        info.min_sdk_version
+      end
+
       def device_type
         info.device_type
       end

--- a/lib/app_info/parser/ipa/info_plist.rb
+++ b/lib/app_info/parser/ipa/info_plist.rb
@@ -32,6 +32,13 @@ module AppInfo
         info.try(:[], 'CFBundleName')
       end
 
+      #
+      # Extract the Minimum OS Version from the Info.plist
+      #
+      def min_sdk_version
+        info.try(:[], 'MinimumOSVersion')
+      end
+
       def icons
         return @icons if @icons
 

--- a/spec/app_info/parser/ipa/info_plist_spec.rb
+++ b/spec/app_info/parser/ipa/info_plist_spec.rb
@@ -11,5 +11,6 @@ describe AppInfo::Parser::InfoPlist do
   it { expect(subject.identifier).to eq('com.icyleaf.AppInfoDemo') }
   it { expect(subject.bundle_id).to eq('com.icyleaf.AppInfoDemo') }
   it { expect(subject.device_type).to eq('iPhone') }
+  it { expect(subject.min_sdk_version).to eq('9.3') }
   it { expect(subject.info).to be_kind_of Hash }
 end

--- a/spec/app_info/parser/ipa_spec.rb
+++ b/spec/app_info/parser/ipa_spec.rb
@@ -17,6 +17,7 @@ describe AppInfo::Parser::IPA do
       it { expect(subject.identifier).to eq('com.icyleaf.AppInfoDemo') }
       it { expect(subject.bundle_id).to eq('com.icyleaf.AppInfoDemo') }
       it { expect(subject.device_type).to eq('iPhone') }
+      it { expect(subject.min_sdk_version).to eq('9.3') }
 
       if AppInfo::Parser.mac?
         it { expect(subject.release_type).to eq('AdHoc')}
@@ -49,6 +50,7 @@ describe AppInfo::Parser::IPA do
       it { expect(subject.file).to eq file }
       it { expect(subject.build_version).to eq('1') }
       it { expect(subject.release_version).to eq('1.0') }
+      it { expect(subject.min_sdk_version).to eq('9.3') }
       it { expect(subject.name).to eq('bundle') }
       it { expect(subject.bundle_name).to eq('bundle') }
       it { expect(subject.display_name).to be_nil }


### PR DESCRIPTION
Change two primary things
1. Updated the CFPropertlyList to the latest version. No test cases broke as a result.
1. Added min_sdk_version to the ipa parser so that it returns the same information as the apk parser.