### PR TITLE
Detect architecture with ipa file

### DIFF
--- a/lib/app_info/ipa.rb
+++ b/lib/app_info/ipa.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'macho'
 require 'pngdefry'
 require 'fileutils'
 require 'cfpropertylist'
@@ -127,6 +128,21 @@ module AppInfo
       end
     end
 
+    def archs
+      return unless File.exist?(bundle_path)
+
+      file = MachO.open(bundle_path)
+      case file
+      when MachO::MachOFile
+        [file.cpusubtype]
+      else
+        file.machos.each_with_object([]) do |arch, obj|
+          obj << arch.cpusubtype
+        end
+      end
+    end
+    alias architectures archs
+
     def stored?
       metadata? ? true : false
     end
@@ -168,6 +184,10 @@ module AppInfo
 
     def metadata_path
       @metadata_path ||= File.join(contents, 'iTunesMetadata.plist')
+    end
+
+    def bundle_path
+      @bundle_path ||= File.join(app_path, info.bundle_name)
     end
 
     def info

--- a/spec/app_info/ipa_spec.rb
+++ b/spec/app_info/ipa_spec.rb
@@ -20,9 +20,10 @@ describe AppInfo::IPA do
       it { expect(subject.min_sdk_version).to eq('9.3') }
       it { expect(subject.info['CFBundleVersion']).to eq('5') }
       it { expect(subject.info[:CFBundleShortVersionString]).to eq('1.2.3') }
+      it { expect(subject.archs).to eq(%i[armv7 arm64]) }
 
-      it { expect(subject.release_type).to eq('AdHoc')}
-      it { expect(subject.build_type).to eq('AdHoc')}
+      it { expect(subject.release_type).to eq('AdHoc') }
+      it { expect(subject.build_type).to eq('AdHoc') }
       it { expect(subject.devices).to be_kind_of Array }
       it { expect(subject.team_name).to eq('QYER Inc') }
       it { expect(subject.profile_name).to eq('iOS Team Provisioning Profile: *') }
@@ -56,9 +57,10 @@ describe AppInfo::IPA do
     it { expect(subject.identifier).to eq('com.icyleaf.bundle') }
     it { expect(subject.bundle_id).to eq('com.icyleaf.bundle') }
     it { expect(subject.device_type).to eq('iPad') }
+    it { expect(subject.archs).to eq(%i[armv7 arm64]) }
 
-    it { expect(subject.release_type).to eq('inHouse')}
-    it { expect(subject.build_type).to eq('inHouse')}
+    it { expect(subject.release_type).to eq('inHouse') }
+    it { expect(subject.build_type).to eq('inHouse') }
     it { expect(subject.devices).to be_nil }
     it { expect(subject.team_name).to eq('QYER Inc') }
     it { expect(subject.profile_name).to eq('XC: *') }


### PR DESCRIPTION
```ruby
parser = AppInfo.parse 'some.ipa'
parser.archs # => [:armv7, :arm64]
parser.archs # => [:arm64]
parser.archs # => nil # No match binary
```
