### PR TITLE
Parse developer certs in mobile_provision

### DIFF
--- a/lib/app_info/ipa/info_plist.rb
+++ b/lib/app_info/ipa/info_plist.rb
@@ -106,6 +106,19 @@ module AppInfo
       info.try(:[], key.to_s)
     end
 
+    def method_missing(method_name, *args, &block)
+      key = if method_name.to_s.include?('_')
+              method_name.to_s
+                         .split('_')
+                         .map(&:capitalize)
+                         .join('')
+            else
+              method_name.to_s
+            end
+
+      info.try(:[], key)
+    end
+
     private
 
     def info


### PR DESCRIPTION
```ruby
mobileprovision = AppInfo::MobileProvision.new 'some.mobileprovision'
mobileprovision.developer_certs.each do |cert|
  cert.name                 # => 'Company Name Co., Ltd.,'
  cert.expired_date         # => 2019-07-18 01:20:20 UTC
  cert.raw.class            # OpenSSL::X509::Certificate
end
```