### PR TITLE
Fix parse aab crash android sdk 31+

### DIFF
--- a/app_info.gemspec
+++ b/app_info.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'CFPropertyList', '< 3.1.0', '>= 2.3.4'
   spec.add_dependency 'image_size', '>= 1.5', '< 3.3'
   spec.add_dependency 'ruby-macho', '>= 1.4', '< 4'
-  spec.add_dependency 'android_parser', '~> 2.5.0'
+  spec.add_dependency 'android_parser', '~> 2.5.1'
   spec.add_dependency 'rubyzip', '>= 1.2', '< 3.0'
   spec.add_dependency 'uuidtools', '>= 2.1.5', '< 2.3.0'
   spec.add_dependency 'icns', '~> 0.2.0'

--- a/lib/app_info/aab.rb
+++ b/lib/app_info/aab.rb
@@ -79,15 +79,15 @@ module AppInfo
     # end
 
     def wear?
-      use_features&.include?('android.hardware.type.watch')
+      !!use_features&.include?('android.hardware.type.watch')
     end
 
     def tv?
-      use_features&.include?('android.software.leanback')
+      !!use_features&.include?('android.software.leanback')
     end
 
     def automotive?
-      use_features&.include?('android.hardware.type.automotive')
+      !!use_features&.include?('android.hardware.type.automotive')
     end
 
     def min_sdk_version

--- a/lib/app_info/protobuf/models/README.md
+++ b/lib/app_info/protobuf/models/README.md
@@ -3,7 +3,7 @@
 ## Convert to ruby model
 
 ```bash
-cd app_info/lib/app_info/abb/proto
+cd lib/app_info/protobuf/models
 
 protoc --ruby_out=. Resources.proto
 protoc --ruby_out=. Configuration.proto

--- a/lib/app_info/protobuf/models/Resources.proto
+++ b/lib/app_info/protobuf/models/Resources.proto
@@ -132,6 +132,11 @@ message Visibility {
 
   // The comment associated with the <public> tag.
   string comment = 3;
+
+  // Indicates that the resource id may change across builds and that the public R.java identifier
+  // for this resource should not be final. This is set to `true` for resources in `staging-group`
+  // tags.
+  bool staged_api = 4;
 }
 
 // Whether a resource comes from a compile-time overlay and is explicitly allowed to not overlay an
@@ -185,6 +190,12 @@ message OverlayableItem {
   uint32 overlayable_idx = 4;
 }
 
+// The staged resource ID definition of a finalized resource.
+message StagedId {
+  Source source = 1;
+  uint32 staged_id = 2;
+}
+
 // An entry ID in the range [0x0000, 0xffff].
 message EntryId {
   uint32 id = 1;
@@ -217,6 +228,9 @@ message Entry {
   // The set of values defined for this entry, each corresponding to a different
   // configuration/variant.
   repeated ConfigValue config_value = 6;
+
+  // The staged resource ID of this finalized resource.
+  StagedId staged_id = 7;
 }
 
 // A Configuration/Value pair.
@@ -268,6 +282,7 @@ message CompoundValue {
     Styleable styleable = 3;
     Array array = 4;
     Plural plural = 5;
+    MacroBody macro = 6;
   }
 }
 
@@ -299,6 +314,13 @@ message Reference {
 
   // Whether this reference is dynamic.
   Boolean is_dynamic = 5;
+
+  // The type flags used when compiling the reference. Used for substituting the contents of macros.
+  uint32 type_flags = 6;
+
+  // Whether raw string values would have been accepted in place of this reference definition. Used
+  // for substituting the contents of macros.
+  bool allow_raw = 7;
 }
 
 // A value that represents an ID. This is just a placeholder, as ID values are used to occupy a
@@ -585,4 +607,33 @@ message XmlAttribute {
 
   // The optional interpreted/compiled version of the `value` string.
   Item compiled_item = 6;
+}
+
+message MacroBody {
+  string raw_string = 1;
+  StyleString style_string = 2;
+  repeated UntranslatableSection untranslatable_sections = 3;
+  repeated NamespaceAlias namespace_stack = 4;
+  SourcePosition source = 5;
+}
+
+message NamespaceAlias {
+  string prefix = 1;
+  string package_name = 2;
+  bool is_private = 3;
+}
+
+message StyleString {
+  message Span {
+    string name = 1;
+    uint32 start_index = 2;
+    uint32 end_index = 3;
+  }
+  string str = 1;
+  repeated Span spans = 2;
+}
+
+message UntranslatableSection {
+  uint64 start_index = 1;
+  uint64 end_index = 2;
 }

--- a/lib/app_info/protobuf/models/Resources_pb.rb
+++ b/lib/app_info/protobuf/models/Resources_pb.rb
@@ -47,6 +47,7 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
       optional :level, :enum, 1, "aapt.pb.Visibility.Level"
       optional :source, :message, 2, "aapt.pb.Source"
       optional :comment, :string, 3
+      optional :staged_api, :bool, 4
     end
     add_enum "aapt.pb.Visibility.Level" do
       value :UNKNOWN, 0
@@ -80,6 +81,10 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
       value :ACTOR, 8
       value :CONFIG_SIGNATURE, 9
     end
+    add_message "aapt.pb.StagedId" do
+      optional :source, :message, 1, "aapt.pb.Source"
+      optional :staged_id, :uint32, 2
+    end
     add_message "aapt.pb.EntryId" do
       optional :id, :uint32, 1
     end
@@ -90,6 +95,7 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
       optional :allow_new, :message, 4, "aapt.pb.AllowNew"
       optional :overlayable_item, :message, 5, "aapt.pb.OverlayableItem"
       repeated :config_value, :message, 6, "aapt.pb.ConfigValue"
+      optional :staged_id, :message, 7, "aapt.pb.StagedId"
     end
     add_message "aapt.pb.ConfigValue" do
       optional :config, :message, 1, "aapt.pb.Configuration"
@@ -122,6 +128,7 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
         optional :styleable, :message, 3, "aapt.pb.Styleable"
         optional :array, :message, 4, "aapt.pb.Array"
         optional :plural, :message, 5, "aapt.pb.Plural"
+        optional :macro, :message, 6, "aapt.pb.MacroBody"
       end
     end
     add_message "aapt.pb.Boolean" do
@@ -133,6 +140,8 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
       optional :name, :string, 3
       optional :private, :bool, 4
       optional :is_dynamic, :message, 5, "aapt.pb.Boolean"
+      optional :type_flags, :uint32, 6
+      optional :allow_raw, :bool, 7
     end
     add_enum "aapt.pb.Reference.Type" do
       value :REFERENCE, 0
@@ -285,6 +294,31 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
       optional :resource_id, :uint32, 5
       optional :compiled_item, :message, 6, "aapt.pb.Item"
     end
+    add_message "aapt.pb.MacroBody" do
+      optional :raw_string, :string, 1
+      optional :style_string, :message, 2, "aapt.pb.StyleString"
+      repeated :untranslatable_sections, :message, 3, "aapt.pb.UntranslatableSection"
+      repeated :namespace_stack, :message, 4, "aapt.pb.NamespaceAlias"
+      optional :source, :message, 5, "aapt.pb.SourcePosition"
+    end
+    add_message "aapt.pb.NamespaceAlias" do
+      optional :prefix, :string, 1
+      optional :package_name, :string, 2
+      optional :is_private, :bool, 3
+    end
+    add_message "aapt.pb.StyleString" do
+      optional :str, :string, 1
+      repeated :spans, :message, 2, "aapt.pb.StyleString.Span"
+    end
+    add_message "aapt.pb.StyleString.Span" do
+      optional :name, :string, 1
+      optional :start_index, :uint32, 2
+      optional :end_index, :uint32, 3
+    end
+    add_message "aapt.pb.UntranslatableSection" do
+      optional :start_index, :uint64, 1
+      optional :end_index, :uint64, 2
+    end
   end
 end
 
@@ -305,6 +339,7 @@ module Aapt
     Overlayable = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("aapt.pb.Overlayable").msgclass
     OverlayableItem = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("aapt.pb.OverlayableItem").msgclass
     OverlayableItem::Policy = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("aapt.pb.OverlayableItem.Policy").enummodule
+    StagedId = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("aapt.pb.StagedId").msgclass
     EntryId = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("aapt.pb.EntryId").msgclass
     Entry = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("aapt.pb.Entry").msgclass
     ConfigValue = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("aapt.pb.ConfigValue").msgclass
@@ -340,5 +375,10 @@ module Aapt
     XmlElement = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("aapt.pb.XmlElement").msgclass
     XmlNamespace = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("aapt.pb.XmlNamespace").msgclass
     XmlAttribute = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("aapt.pb.XmlAttribute").msgclass
+    MacroBody = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("aapt.pb.MacroBody").msgclass
+    NamespaceAlias = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("aapt.pb.NamespaceAlias").msgclass
+    StyleString = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("aapt.pb.StyleString").msgclass
+    StyleString::Span = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("aapt.pb.StyleString.Span").msgclass
+    UntranslatableSection = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("aapt.pb.UntranslatableSection").msgclass
   end
 end

--- a/spec/app_info/aab_spec.rb
+++ b/spec/app_info/aab_spec.rb
@@ -1,39 +1,76 @@
 describe AppInfo::APK do
   describe '#PhoneOrTablet' do
-    let(:file) { fixture_path('apps/android.aab') }
     subject { AppInfo::AAB.new(file) }
-
     after { subject.clear! }
 
-    it { expect(subject.size).to eq(3618865) }
-    it { expect(subject.size(human_size: true)).to eq('3.45 MB') }
-    it { expect(subject.os).to eq 'Android' }
-    it { expect(subject.wear?).to be false }
-    it { expect(subject.tv?).to be false }
-    it { expect(subject.automotive?).to be false }
-    it { expect(subject.os).to eq AppInfo::Platform::ANDROID }
-    it { expect(subject.file).to eq file }
-    it { expect(subject.release_version).to eq('2.1.0') }
-    it { expect(subject.build_version).to eq('10') }
-    it { expect(subject.name).to eq('AppInfoDemo') }
-    it { expect(subject.bundle_id).to eq('com.icyleaf.appinfodemo') }
-    it { expect(subject.identifier).to eq('com.icyleaf.appinfodemo') }
-    it { expect(subject.icons.length).not_to be_nil }
-    it { expect(subject.min_sdk_version).to eq 14 }
-    it { expect(subject.target_sdk_version).to eq 31 }
-    it { expect(subject.deep_links).to eq(['icyleaf.com']) }
-    it { expect(subject.schemes).to eq(['appinfo']) }
-    it { expect(subject.certificates.first).to be_kind_of(AppInfo::APK::Certificate) }
-    it { expect(subject.certificates.first.path).to eq('META-INF/KEY0.RSA') }
-    it { expect(subject.certificates.first.certificate).to be_kind_of(OpenSSL::X509::Certificate) }
-    it { expect(subject.signs.first).to be_kind_of(AppInfo::APK::Sign) }
-    it { expect(subject.signs.first.path).to eq('META-INF/KEY0.RSA') }
-    it { expect(subject.signs.first.sign).to be_kind_of(OpenSSL::PKCS7) }
-    it { expect(subject.activities.size).to eq(2) }
-    it { expect(subject.services.size).to eq(0) }
-    it { expect(subject.components.size).to eq(1) }
-    it { expect(subject.use_permissions).to eq(%w[android.permission.ACCESS_NETWORK_STATE]) }
-    it { expect(subject.use_features).to eq(%w[android.hardware.bluetooth]) }
-    it { expect(subject.manifest).to be_kind_of AppInfo::Protobuf::Manifest }
+    context 'with Android target SDK under 31' do
+      let(:file) { fixture_path('apps/android.aab') }
+
+      it { expect(subject.size).to eq(3618865) }
+      it { expect(subject.size(human_size: true)).to eq('3.45 MB') }
+      it { expect(subject.os).to eq 'Android' }
+      it { expect(subject.wear?).to be false }
+      it { expect(subject.tv?).to be false }
+      it { expect(subject.automotive?).to be false }
+      it { expect(subject.os).to eq AppInfo::Platform::ANDROID }
+      it { expect(subject.file).to eq file }
+      it { expect(subject.release_version).to eq('2.1.0') }
+      it { expect(subject.build_version).to eq('10') }
+      it { expect(subject.name).to eq('AppInfoDemo') }
+      it { expect(subject.bundle_id).to eq('com.icyleaf.appinfodemo') }
+      it { expect(subject.icons.length).not_to be_nil }
+      it { expect(subject.min_sdk_version).to eq 14 }
+      it { expect(subject.target_sdk_version).to eq 31 }
+      it { expect(subject.deep_links).to eq(['icyleaf.com']) }
+      it { expect(subject.schemes).to eq(['appinfo']) }
+      it { expect(subject.certificates.first).to be_kind_of(AppInfo::APK::Certificate) }
+      it { expect(subject.certificates.first.path).to eq('META-INF/KEY0.RSA') }
+      it { expect(subject.certificates.first.certificate).to be_kind_of(OpenSSL::X509::Certificate) }
+      it { expect(subject.signs.first).to be_kind_of(AppInfo::APK::Sign) }
+      it { expect(subject.signs.first.path).to eq('META-INF/KEY0.RSA') }
+      it { expect(subject.signs.first.sign).to be_kind_of(OpenSSL::PKCS7) }
+      it { expect(subject.activities.size).to eq(2) }
+      it { expect(subject.services.size).to eq(0) }
+      it { expect(subject.components.size).to eq(1) }
+      it { expect(subject.use_permissions).to eq(%w[android.permission.ACCESS_NETWORK_STATE]) }
+      it { expect(subject.use_features).to eq(%w[android.hardware.bluetooth]) }
+      it { expect(subject.manifest).to be_kind_of AppInfo::Protobuf::Manifest }
+      it { expect(subject.manifest.label).to eq('AppInfoDemo') }
+      it { expect(subject.manifest.label(locale: 'en')).to eq('AppInfoDemo') }
+      it { expect(subject.manifest.label(locale: 'zh-CN')).to eq('AppInfo演示') }
+    end
+
+    context 'with Android target SDK above 31' do
+      let(:file) { fixture_path('apps/android-31.aab') }
+
+      it { expect(subject.size).to eq(7448532) }
+      it { expect(subject.size(human_size: true)).to eq('7.10 MB') }
+      it { expect(subject.os).to eq 'Android' }
+      it { expect(subject.wear?).to be false }
+      it { expect(subject.tv?).to be false }
+      it { expect(subject.automotive?).to be false }
+      it { expect(subject.os).to eq AppInfo::Platform::ANDROID }
+      it { expect(subject.file).to eq file }
+      it { expect(subject.release_version).to eq('1.0') }
+      it { expect(subject.build_version).to eq('1') }
+      it { expect(subject.name).to eq('My Application') }
+      it { expect(subject.bundle_id).to eq('com.example.myapplication') }
+      it { expect(subject.icons.length).not_to be_nil }
+      it { expect(subject.min_sdk_version).to eq 24 }
+      it { expect(subject.target_sdk_version).to eq 33 }
+      it { expect(subject.deep_links).to eq([]) }
+      it { expect(subject.schemes).to eq([]) }
+      it { expect(subject.certificates).to be_empty }
+      it { expect(subject.signs).to be_empty }
+      it { expect(subject.activities.size).to eq(3) }
+      it { expect(subject.services.size).to eq(0) }
+      it { expect(subject.components.size).to eq(3) }
+      it { expect(subject.use_permissions).to eq(%w[com.example.myapplication.DYNAMIC_RECEIVER_NOT_EXPORTED_PERMISSION]) }
+      it { expect(subject.use_features).to be_nil }
+      it { expect(subject.manifest).to be_kind_of AppInfo::Protobuf::Manifest }
+      it { expect(subject.manifest.label).to eq('My Application') }
+      it { expect(subject.manifest.label(locale: 'en')).to eq('My Application') }
+      it { expect(subject.manifest.label(locale: 'zh-CN')).to eq('My Application') }
+    end
   end
 end

--- a/spec/app_info_spec.rb
+++ b/spec/app_info_spec.rb
@@ -9,6 +9,7 @@ MATCH_FILE_TYPES = {
   'wear.apk' => :apk,
   'automotive.apk' => :apk,
   'android.aab' => :aab,
+  'android-31.aab' => :aab,
   'ipad.ipa' => :ipa,
   'iphone.ipa' => :ipa,
   'embedded.ipa' => :ipa,


### PR DESCRIPTION
Fixes #51 and minor other bugfix.

Thanks the [reproduced android project](https://github.com/jimmymorales/app-info-crash-test).