### PR TITLE
[BREAKING CHANGES] All supported parser based on AppInfo::File

### DIFF
--- a/lib/app_info.rb
+++ b/lib/app_info.rb
@@ -5,6 +5,7 @@ require 'app_info/error'
 require 'app_info/core_ext'
 require 'app_info/helper'
 
+require 'app_info/file'
 require 'app_info/info_plist'
 require 'app_info/mobile_provision'
 
@@ -36,7 +37,7 @@ module AppInfo
 
     # Get a new parser for automatic
     def parse(file)
-      raise NotFoundError, file unless File.exist?(file)
+      raise NotFoundError, file unless ::File.exist?(file)
 
       case file_type(file)
       when Format::IPA then IPA.new(file)
@@ -61,7 +62,7 @@ module AppInfo
     #
     # TODO: This can be better solution, if anyone knows, tell me please.
     def file_type(file)
-      header_hex = File.read(file, 100)
+      header_hex = ::File.read(file, 100)
       case header_hex
       when ZIP_RETGEX
         detect_zip_file(file)

--- a/lib/app_info/aab.rb
+++ b/lib/app_info/aab.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'app_info/android/signature_verify'
 require 'app_info/protobuf/manifest'
 require 'image_size'
 require 'forwardable'

--- a/lib/app_info/apk.rb
+++ b/lib/app_info/apk.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'app_info/android/signature_verify'
 require 'ruby_apk'
 require 'image_size'
 require 'forwardable'

--- a/lib/app_info/apk.rb
+++ b/lib/app_info/apk.rb
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
 
+require 'app_info/android/signature_verify'
 require 'ruby_apk'
 require 'image_size'
 require 'forwardable'
 
 module AppInfo
   # Parse APK file
-  class APK
+  class APK < File
     include Helper::HumanFileSize
     extend Forwardable
 
@@ -21,18 +22,17 @@ module AppInfo
       AUTOMOTIVE  = 'Automotive'
     end
 
-    def initialize(file)
-      @file = file
-    end
-
     def size(human_size: false)
       file_to_human_size(@file, human_size: human_size)
     end
 
-    def os
+    def file_type
+      Format::APK
+    end
+
+    def platform
       Platform::ANDROID
     end
-    alias file_type os
 
     def_delegators :apk, :manifest, :resource, :dex
 
@@ -120,11 +120,11 @@ module AppInfo
 
     def icons
       @icons ||= apk.icon.each_with_object([]) do |(path, data), obj|
-        icon_name = File.basename(path)
-        icon_path = File.join(contents, File.dirname(path))
-        icon_file = File.join(icon_path, icon_name)
+        icon_name = ::File.basename(path)
+        icon_path = ::File.join(contents, ::File.dirname(path))
+        icon_file = ::File.join(icon_path, icon_name)
         FileUtils.mkdir_p icon_path
-        File.write(icon_file, data, encoding: Encoding::BINARY)
+        ::File.write(icon_file, data, encoding: Encoding::BINARY)
 
         obj << {
           name: icon_name,
@@ -147,7 +147,7 @@ module AppInfo
     end
 
     def contents
-      @contents ||= File.join(Dir.mktmpdir, "AppInfo-android-#{SecureRandom.hex}")
+      @contents ||= ::File.join(Dir.mktmpdir, "AppInfo-android-#{SecureRandom.hex}")
     end
 
     # Android Certificate

--- a/lib/app_info/dsym.rb
+++ b/lib/app_info/dsym.rb
@@ -4,21 +4,17 @@ require 'macho'
 
 module AppInfo
   # DSYM parser
-  class DSYM
+  class DSYM < File
     include Helper::Archive
 
     attr_reader :file
 
-    def initialize(file)
-      @file = file
-    end
-
     def file_type
-      Platform::DSYM
+      Format::DSYM
     end
 
     def object
-      @object ||= File.basename(app_path)
+      @object ||= ::File.basename(app_path)
     end
 
     def macho_type
@@ -28,7 +24,7 @@ module AppInfo
     def machos
       @machos ||= case macho_type
                   when ::MachO::MachOFile
-                    [MachO.new(macho_type, File.size(app_path))]
+                    [MachO.new(macho_type, ::File.size(app_path))]
                   else
                     size = macho_type.fat_archs.each_with_object([]) do |arch, obj|
                       obj << arch.size
@@ -56,20 +52,20 @@ module AppInfo
     alias bundle_id identifier
 
     def info
-      return nil unless File.exist?(info_path)
+      return nil unless ::File.exist?(info_path)
 
       @info ||= CFPropertyList.native_types(CFPropertyList::List.new(file: info_path).value)
     end
 
     def info_path
-      @info_path ||= File.join(contents, 'Contents', 'Info.plist')
+      @info_path ||= ::File.join(contents, 'Contents', 'Info.plist')
     end
 
     def app_path
       unless @app_path
-        path = File.join(contents, 'Contents', 'Resources', 'DWARF')
+        path = ::File.join(contents, 'Contents', 'Resources', 'DWARF')
         name = Dir.entries(path).reject { |f| ['.', '..'].include?(f) }.first
-        @app_path = File.join(path, name)
+        @app_path = ::File.join(path, name)
       end
 
       @app_path
@@ -89,7 +85,7 @@ module AppInfo
 
     def contents
       unless @contents
-        if File.directory?(@file)
+        if ::File.directory?(@file)
           @contents = @file
         else
           dsym_dir = nil
@@ -101,13 +97,13 @@ module AppInfo
                 dsym_dir = dsym_dir.split('/')[0] if dsym_dir.include?('/')
               end
 
-              f_path = File.join(path, f.name)
-              FileUtils.mkdir_p(File.dirname(f_path))
-              f.extract(f_path) unless File.exist?(f_path)
+              f_path = ::File.join(path, f.name)
+              FileUtils.mkdir_p(::File.dirname(f_path))
+              f.extract(f_path) unless ::File.exist?(f_path)
             end
           end
 
-          @contents = File.join(@contents, dsym_dir)
+          @contents = ::File.join(@contents, dsym_dir)
         end
       end
 

--- a/lib/app_info/file.rb
+++ b/lib/app_info/file.rb
@@ -1,19 +1,20 @@
-
 # frozen_string_literal: true
 
 # AppInfo base file
-class AppInfo::File
-  attr_reader :file
+module AppInfo
+  class File
+    attr_reader :file
 
-  def initialize(file)
-    @file = file
-  end
+    def initialize(file)
+      @file = file
+    end
 
-  def file_type
-    Platform::UNKNOWN
-  end
+    def file_type
+      Platform::UNKNOWN
+    end
 
-  def size
-    raise 'implantation required'
+    def size
+      raise 'implantation required'
+    end
   end
 end

--- a/lib/app_info/file.rb
+++ b/lib/app_info/file.rb
@@ -1,0 +1,19 @@
+
+# frozen_string_literal: true
+
+# AppInfo base file
+class AppInfo::File
+  attr_reader :file
+
+  def initialize(file)
+    @file = file
+  end
+
+  def file_type
+    Platform::UNKNOWN
+  end
+
+  def size
+    raise 'implantation required'
+  end
+end

--- a/lib/app_info/helper.rb
+++ b/lib/app_info/helper.rb
@@ -30,8 +30,6 @@ module AppInfo
     MACOS = 'macOS'
     IOS = 'iOS'
     ANDROID = 'Android'
-    DSYM = 'dSYM'
-    PROGUARD = 'Proguard'
   end
 
   # Apple Device Type
@@ -60,7 +58,7 @@ module AppInfo
   module Helper
     module HumanFileSize
       def file_to_human_size(file, human_size:)
-        number = File.size(file)
+        number = ::File.size(file)
         human_size ? number_to_human_size(number) : number
       end
 
@@ -96,9 +94,9 @@ module AppInfo
             yield root_path, zip_file
           else
             zip_file.each do |f|
-              f_path = File.join(root_path, f.name)
-              FileUtils.mkdir_p(File.dirname(f_path))
-              zip_file.extract(f, f_path) unless File.exist?(f_path)
+              f_path = ::File.join(root_path, f.name)
+              FileUtils.mkdir_p(::File.dirname(f_path))
+              zip_file.extract(f, f_path) unless ::File.exist?(f_path)
             end
           end
         end
@@ -108,12 +106,12 @@ module AppInfo
 
       def tempdir(file, prefix:, system: false)
         dest_path = if system
-                      Dir.mktmpdir("appinfo-#{prefix}-#{File.basename(file, '.*')}-", '/tmp')
+                      Dir.mktmpdir("appinfo-#{prefix}-#{::File.basename(file, '.*')}-", '/tmp')
                     else
-                      File.join(File.dirname(file), prefix)
+                      ::File.join(::File.dirname(file), prefix)
                     end
 
-        dest_file = File.join(dest_path, File.basename(file))
+        dest_file = ::File.join(dest_path, ::File.basename(file))
         FileUtils.mkdir_p(dest_path, mode: 0_700) unless system
         dest_file
       end

--- a/lib/app_info/helper.rb
+++ b/lib/app_info/helper.rb
@@ -7,6 +7,7 @@ module AppInfo
   module Format
     # iOS
     IPA = :ipa
+    INFOPLIST = :infoplist
     MOBILEPROVISION = :mobileprovision
     DSYM = :dsym
 

--- a/lib/app_info/info_plist.rb
+++ b/lib/app_info/info_plist.rb
@@ -6,11 +6,11 @@ require 'app_info/png_uncrush'
 
 module AppInfo
   # iOS Info.plist parser
-  class InfoPlist
+  class InfoPlist < File
     extend Forwardable
 
-    def initialize(file)
-      @file = file
+    def file_type
+      Format::INFOPLIST
     end
 
     def version
@@ -126,7 +126,7 @@ module AppInfo
     private
 
     def info
-      return unless File.file?(@file)
+      return unless ::File.file?(@file)
 
       @info ||= CFPropertyList.native_types(CFPropertyList::List.new(file: @file).value)
     end
@@ -134,9 +134,9 @@ module AppInfo
     def app_path
       @app_path ||= case device_type
                     when Device::MACOS
-                      File.dirname(@file)
+                      ::File.dirname(@file)
                     else
-                      File.expand_path('../', @file)
+                      ::File.expand_path('../', @file)
                     end
     end
   end

--- a/lib/app_info/ipa.rb
+++ b/lib/app_info/ipa.rb
@@ -7,7 +7,7 @@ require 'cfpropertylist'
 
 module AppInfo
   # IPA parser
-  class IPA
+  class IPA < File
     include Helper::HumanFileSize
     include Helper::Archive
     extend Forwardable
@@ -25,18 +25,17 @@ module AppInfo
       INHOUSE = 'Enterprise' # Rename and Alias to enterprise
     end
 
-    def initialize(file)
-      @file = file
-    end
-
     def size(human_size: false)
       file_to_human_size(@file, human_size: human_size)
     end
 
-    def os
+    def file_type
+      Format::IPA
+    end
+
+    def platform
       Platform::IOS
     end
-    alias file_type os
 
     def_delegators :info, :iphone?, :ipad?, :universal?, :build_version, :name,
                    :release_version, :identifier, :bundle_id, :display_name,
@@ -70,7 +69,7 @@ module AppInfo
     end
 
     def archs
-      return unless File.exist?(bundle_path)
+      return unless ::File.exist?(bundle_path)
 
       file = MachO.open(bundle_path)
       case file
@@ -114,14 +113,14 @@ module AppInfo
     end
 
     def mobileprovision?
-      File.exist?(mobileprovision_path)
+      ::File.exist?(mobileprovision_path)
     end
 
     def mobileprovision_path
       filename = 'embedded.mobileprovision'
-      @mobileprovision_path ||= File.join(@file, filename)
-      unless File.exist?(@mobileprovision_path)
-        @mobileprovision_path = File.join(app_path, filename)
+      @mobileprovision_path ||= ::File.join(@file, filename)
+      unless ::File.exist?(@mobileprovision_path)
+        @mobileprovision_path = ::File.join(app_path, filename)
       end
 
       @mobileprovision_path
@@ -134,15 +133,15 @@ module AppInfo
     end
 
     def metadata?
-      File.exist?(metadata_path)
+      ::File.exist?(metadata_path)
     end
 
     def metadata_path
-      @metadata_path ||= File.join(contents, 'iTunesMetadata.plist')
+      @metadata_path ||= ::File.join(contents, 'iTunesMetadata.plist')
     end
 
     def bundle_path
-      @bundle_path ||= File.join(app_path, info.bundle_name)
+      @bundle_path ||= ::File.join(app_path, info.bundle_name)
     end
 
     def info
@@ -150,35 +149,32 @@ module AppInfo
     end
 
     def info_path
-      @info_path ||= File.join(app_path, 'Info.plist')
+      @info_path ||= ::File.join(app_path, 'Info.plist')
     end
 
     def app_path
-      @app_path ||= Dir.glob(File.join(contents, 'Payload', '*.app')).first
+      @app_path ||= Dir.glob(::File.join(contents, 'Payload', '*.app')).first
     end
 
     IPHONE_KEY = 'CFBundleIcons'
     IPAD_KEY = 'CFBundleIcons~ipad'
 
     def icons_path
-      return @icons_path if @icons_path
+      @icons_path ||= lambda {
+        icon_keys.each_with_object([]) do |name, icons|
+          filenames = info.try(:[], name)
+                          .try(:[], 'CFBundlePrimaryIcon')
+                          .try(:[], 'CFBundleIconFiles')
 
-      @icons_path = []
-      icon_keys.each do |name|
-        filenames = info.try(:[], name)
-                        .try(:[], 'CFBundlePrimaryIcon')
-                        .try(:[], 'CFBundleIconFiles')
+          next if filenames.nil? || filenames.empty?
 
-        next if filenames.nil? || filenames.empty?
-
-        filenames.each do |filename|
-          Dir.glob(File.join(app_path, "#{filename}*")).find_all.each do |file|
-            @icons_path << file
+          filenames.each do |filename|
+            Dir.glob(::File.join(app_path, "#{filename}*")).find_all.each do |file|
+              icons << file
+            end
           end
         end
-      end
-
-      @icons_path
+      }.call
     end
 
     def clear!
@@ -206,7 +202,7 @@ module AppInfo
       uncrushed_file = uncrush ? uncrush_png(file) : nil
 
       {
-        name: File.basename(file),
+        name: ::File.basename(file),
         file: file,
         uncrushed_file: uncrushed_file,
         dimensions: PngUncrush.dimensions(file)
@@ -217,18 +213,18 @@ module AppInfo
     def uncrush_png(src_file)
       dest_file = tempdir(src_file, prefix: 'uncrushed')
       PngUncrush.decompress(src_file, dest_file)
-      File.exist?(dest_file) ? dest_file : nil
+      ::File.exist?(dest_file) ? dest_file : nil
     end
 
     def icon_keys
       @icon_keys ||= case device_type
-                     when 'iPhone'
-                       [IPHONE_KEY]
-                     when 'iPad'
-                       [IPAD_KEY]
-                     when 'Universal'
-                       [IPHONE_KEY, IPAD_KEY]
-                     end
+        when 'iPhone'
+          [IPHONE_KEY]
+        when 'iPad'
+          [IPAD_KEY]
+        when 'Universal'
+          [IPHONE_KEY, IPAD_KEY]
+        end
     end
   end
 end

--- a/lib/app_info/ipa.rb
+++ b/lib/app_info/ipa.rb
@@ -218,13 +218,13 @@ module AppInfo
 
     def icon_keys
       @icon_keys ||= case device_type
-        when 'iPhone'
-          [IPHONE_KEY]
-        when 'iPad'
-          [IPAD_KEY]
-        when 'Universal'
-          [IPHONE_KEY, IPAD_KEY]
-        end
+                     when 'iPhone'
+                       [IPHONE_KEY]
+                     when 'iPad'
+                       [IPAD_KEY]
+                     when 'Universal'
+                       [IPHONE_KEY, IPAD_KEY]
+                     end
     end
   end
 end

--- a/lib/app_info/ipa/framework.rb
+++ b/lib/app_info/ipa/framework.rb
@@ -8,7 +8,7 @@ module AppInfo
     extend Forwardable
 
     def self.parse(path, name = 'Frameworks')
-      files = Dir.glob(File.join(path, name.to_s, '*'))
+      files = Dir.glob(::File.join(path, name.to_s, '*'))
       return [] if files.empty?
 
       files.sort.each_with_object([]) do |file, obj|
@@ -26,7 +26,7 @@ module AppInfo
     end
 
     def name
-      File.basename(file)
+      ::File.basename(file)
     end
 
     def macho
@@ -37,11 +37,11 @@ module AppInfo
     end
 
     def lib?
-      File.file?(file)
+      ::File.file?(file)
     end
 
     def info
-      @info ||= InfoPlist.new(File.join(file, 'Info.plist'))
+      @info ||= InfoPlist.new(::File.join(file, 'Info.plist'))
     end
 
     def to_s

--- a/lib/app_info/mobile_provision.rb
+++ b/lib/app_info/mobile_provision.rb
@@ -5,9 +5,9 @@ require 'cfpropertylist'
 
 module AppInfo
   # .mobileprovision file parser
-  class MobileProvision
-    def initialize(path)
-      @path = path
+  class MobileProvision < File
+    def file_type
+      Format::MOBILEPROVISION
     end
 
     def name
@@ -142,10 +142,10 @@ module AppInfo
         when 'com.apple.developer.networking.vpn.api'
           capabilities << 'Personal VPN'
         when 'com.apple.developer.healthkit',
-             'com.apple.developer.healthkit.access'
+            'com.apple.developer.healthkit.access'
           capabilities << 'HealthKit' unless capabilities.include?('HealthKit')
         when 'com.apple.developer.icloud-services',
-             'com.apple.developer.icloud-container-identifiers'
+            'com.apple.developer.icloud-container-identifiers'
           capabilities << 'iCloud' unless capabilities.include?('iCloud')
         when 'com.apple.developer.in-app-payments'
           capabilities << 'Apple Pay'
@@ -201,9 +201,9 @@ module AppInfo
     end
 
     def mobileprovision
-      return @mobileprovision = nil unless File.exist?(@path)
+      return @mobileprovision = nil unless ::File.exist?(@file)
 
-      data = File.read(@path)
+      data = ::File.read(@file)
       data = strip_plist_wrapper(data) unless bplist?(data)
       list = CFPropertyList::List.new(data: data).value
       @mobileprovision = CFPropertyList.native_types(list)

--- a/lib/app_info/png_uncrush.rb
+++ b/lib/app_info/png_uncrush.rb
@@ -69,7 +69,7 @@ module AppInfo
     end
 
     def initialize(filename)
-      @io = PngReader.new(File.open(filename))
+      @io = PngReader.new(::File.open(filename))
       raise FormatError, 'not a png file' unless @io.png?
     end
 
@@ -125,7 +125,7 @@ module AppInfo
     end
 
     def write_file(path, content)
-      File.write(path, content, encoding: Encoding::BINARY)
+      ::File.write(path, content, encoding: Encoding::BINARY)
       true
     end
 

--- a/lib/app_info/proguard.rb
+++ b/lib/app_info/proguard.rb
@@ -5,37 +5,31 @@ require 'rexml/document'
 
 module AppInfo
   # Proguard parser
-  class Proguard
+  class Proguard < File
     include Helper::Archive
 
     NAMESPACE = UUIDTools::UUID.sha1_create(UUIDTools::UUID_DNS_NAMESPACE, 'icyleaf.com')
 
-    attr_reader :file
-
-    def initialize(file)
-      @file = file
-    end
-
     def file_type
-      Platform::PROGUARD
+      Format::PROGUARD
     end
 
     def uuid
       # Similar to https://docs.sentry.io/workflow/debug-files/#proguard-uuids
-      UUIDTools::UUID.sha1_create(NAMESPACE, File.read(mapping_path)).to_s
+      UUIDTools::UUID.sha1_create(NAMESPACE, ::File.read(mapping_path)).to_s
     end
     alias debug_id uuid
 
     def mapping?
-      File.exist?(mapping_path)
+      ::File.exist?(mapping_path)
     end
 
     def manifest?
-      File.exist?(manifest_path)
+      ::File.exist?(manifest_path)
     end
 
     def symbol?
-      File.exist?(symbol_path)
+      ::File.exist?(symbol_path)
     end
     alias resource? symbol?
 
@@ -68,19 +62,19 @@ module AppInfo
     def manifest
       return unless manifest?
 
-      @manifest ||= REXML::Document.new(File.new(manifest_path))
+      @manifest ||= REXML::Document.new(::File.new(manifest_path))
     end
 
     def mapping_path
-      @mapping_path ||= Dir.glob(File.join(contents, '*mapping*.txt')).first
+      @mapping_path ||= Dir.glob(::File.join(contents, '*mapping*.txt')).first
     end
 
     def manifest_path
-      @manifest_path ||= File.join(contents, 'AndroidManifest.xml')
+      @manifest_path ||= ::File.join(contents, 'AndroidManifest.xml')
     end
 
     def symbol_path
-      @symbol_path ||= File.join(contents, 'R.txt')
+      @symbol_path ||= ::File.join(contents, 'R.txt')
     end
     alias resource_path symbol_path
 

--- a/spec/app_info/aab_spec.rb
+++ b/spec/app_info/aab_spec.rb
@@ -8,11 +8,13 @@ describe AppInfo::APK do
 
       it { expect(subject.size).to eq(3618865) }
       it { expect(subject.size(human_size: true)).to eq('3.45 MB') }
-      it { expect(subject.os).to eq 'Android' }
+      it { expect(subject.file_type).to eq :aab }
+      it { expect(subject.file_type).to eq AppInfo::Format::AAB }
+      it { expect(subject.platform).to eq 'Android' }
+      it { expect(subject.platform).to eq AppInfo::Platform::ANDROID }
       it { expect(subject.wear?).to be false }
       it { expect(subject.tv?).to be false }
       it { expect(subject.automotive?).to be false }
-      it { expect(subject.os).to eq AppInfo::Platform::ANDROID }
       it { expect(subject.file).to eq file }
       it { expect(subject.release_version).to eq('2.1.0') }
       it { expect(subject.build_version).to eq('10') }
@@ -45,11 +47,13 @@ describe AppInfo::APK do
 
       it { expect(subject.size).to eq(7448532) }
       it { expect(subject.size(human_size: true)).to eq('7.10 MB') }
-      it { expect(subject.os).to eq 'Android' }
+      it { expect(subject.file_type).to eq :aab }
+      it { expect(subject.file_type).to eq AppInfo::Format::AAB }
+      it { expect(subject.platform).to eq 'Android' }
+      it { expect(subject.platform).to eq AppInfo::Platform::ANDROID }
       it { expect(subject.wear?).to be false }
       it { expect(subject.tv?).to be false }
       it { expect(subject.automotive?).to be false }
-      it { expect(subject.os).to eq AppInfo::Platform::ANDROID }
       it { expect(subject.file).to eq file }
       it { expect(subject.release_version).to eq('1.0') }
       it { expect(subject.build_version).to eq('1') }

--- a/spec/app_info/apk_spec.rb
+++ b/spec/app_info/apk_spec.rb
@@ -8,11 +8,13 @@ describe AppInfo::APK do
       let(:file) { fixture_path('apps/android.apk') }
       it { expect(subject.size).to eq(4000563) }
       it { expect(subject.size(human_size: true)).to eq('3.82 MB') }
-      it { expect(subject.os).to eq 'Android' }
+      it { expect(subject.file_type).to eq :apk }
+      it { expect(subject.file_type).to eq AppInfo::Format::APK }
+      it { expect(subject.platform).to eq 'Android' }
+      it { expect(subject.platform).to eq AppInfo::Platform::ANDROID }
       it { expect(subject.wear?).to be false }
       it { expect(subject.tv?).to be false }
       it { expect(subject.automotive?).to be false }
-      it { expect(subject.os).to eq AppInfo::Platform::ANDROID }
       it { expect(subject.device_type).to eq AppInfo::APK::Device::PHONE }
       it { expect(subject.file).to eq file }
       it { expect(subject.apk).to be_a Android::Apk }
@@ -54,11 +56,13 @@ describe AppInfo::APK do
 
     after { subject.clear! }
 
-    it { expect(subject.os).to eq 'Android' }
+    it { expect(subject.file_type).to eq :apk }
+    it { expect(subject.file_type).to eq AppInfo::Format::APK }
+    it { expect(subject.platform).to eq 'Android' }
+    it { expect(subject.platform).to eq AppInfo::Platform::ANDROID }
     it { expect(subject.wear?).to be true }
     it { expect(subject.tv?).to be false }
     it { expect(subject.automotive?).to be false }
-    it { expect(subject.os).to eq AppInfo::Platform::ANDROID }
     it { expect(subject.device_type).to eq AppInfo::APK::Device::WATCH }
     it { expect(subject.file).to eq file }
     it { expect(subject.apk).to be_a Android::Apk }
@@ -78,11 +82,13 @@ describe AppInfo::APK do
 
     after { subject.clear! }
 
-    it { expect(subject.os).to eq 'Android' }
+    it { expect(subject.file_type).to eq :apk }
+    it { expect(subject.file_type).to eq AppInfo::Format::APK }
+    it { expect(subject.platform).to eq 'Android' }
+    it { expect(subject.platform).to eq AppInfo::Platform::ANDROID }
     it { expect(subject.wear?).to be false }
     it { expect(subject.tv?).to be true }
     it { expect(subject.automotive?).to be false }
-    it { expect(subject.os).to eq AppInfo::Platform::ANDROID }
     it { expect(subject.device_type).to eq AppInfo::APK::Device::TV }
     it { expect(subject.file).to eq file }
     it { expect(subject.apk).to be_a Android::Apk }
@@ -102,11 +108,13 @@ describe AppInfo::APK do
 
     after { subject.clear! }
 
-    it { expect(subject.os).to eq 'Android' }
+    it { expect(subject.file_type).to eq :apk }
+    it { expect(subject.file_type).to eq AppInfo::Format::APK }
+    it { expect(subject.platform).to eq 'Android' }
+    it { expect(subject.platform).to eq AppInfo::Platform::ANDROID }
     it { expect(subject.wear?).to be false }
     it { expect(subject.tv?).to be false }
     it { expect(subject.automotive?).to be true }
-    it { expect(subject.os).to eq AppInfo::Platform::ANDROID }
     it { expect(subject.device_type).to eq AppInfo::APK::Device::AUTOMOTIVE }
     it { expect(subject.file).to eq file }
     it { expect(subject.apk).to be_a Android::Apk }

--- a/spec/app_info/dsym_spec.rb
+++ b/spec/app_info/dsym_spec.rb
@@ -14,7 +14,8 @@ describe AppInfo::DSYM do
         human_size: '846.59 KB'
       }
 
-      it { expect(subject.file_type).to eq AppInfo::Platform::DSYM }
+      it { expect(subject.file_type).to eq AppInfo::Format::DSYM }
+      it { expect(subject.file_type).to eq :dsym }
       it { expect(subject.object).to eq 'iOS' }
       it { expect(subject.macho_type).to be_a ::MachO::MachOFile }
       it { expect(subject.release_version).to eq '1.0' }
@@ -57,7 +58,8 @@ describe AppInfo::DSYM do
         }
       ]
 
-      it { expect(subject.file_type).to eq AppInfo::Platform::DSYM }
+      it { expect(subject.file_type).to eq AppInfo::Format::DSYM }
+      it { expect(subject.file_type).to eq :dsym }
       it { expect(subject.object).to eq 'iOS' }
       it { expect(subject.macho_type).to be_a ::MachO::FatFile }
       it { expect(subject.release_version).to eq '1.0' }

--- a/spec/app_info/info_plist_spec.rb
+++ b/spec/app_info/info_plist_spec.rb
@@ -3,6 +3,9 @@ describe AppInfo::InfoPlist do
     let(:app) { AppInfo::IPA.new(fixture_path('apps/ipad.ipa')) }
     subject { AppInfo::InfoPlist.new(app.info_path) }
 
+    it { expect(subject.file_type).to eq(AppInfo::Format::INFOPLIST) }
+    it { expect(subject.file_type).to eq(:infoplist) }
+    it { expect(subject.build_version).to eq('1') }
     it { expect(subject.build_version).to eq('1') }
     it { expect(subject.release_version).to eq('1.0') }
     it { expect(subject.name).to eq('bundle') }
@@ -26,6 +29,8 @@ describe AppInfo::InfoPlist do
     let(:app) { AppInfo::Macos.new(fixture_path('apps/macos.zip')) }
     subject { AppInfo::InfoPlist.new(app.info_path) }
 
+    it { expect(subject.file_type).to eq(AppInfo::Format::INFOPLIST) }
+    it { expect(subject.file_type).to eq(:infoplist) }
     it { expect(subject.build_version).to eq('1') }
     it { expect(subject.release_version).to eq('1.0') }
     it { expect(subject.name).to eq('GuiApp') }

--- a/spec/app_info/ipa_spec.rb
+++ b/spec/app_info/ipa_spec.rb
@@ -6,7 +6,10 @@ describe AppInfo::IPA do
     after { subject.clear! }
 
     context 'parse' do
-      it { expect(subject.os).to eq 'iOS' }
+      it { expect(subject.file_type).to eq AppInfo::Format::IPA }
+      it { expect(subject.file_type).to eq :ipa }
+      it { expect(subject.platform).to eq 'iOS' }
+      it { expect(subject.platform).to eq AppInfo::Platform::IOS }
       it { expect(subject).to be_iphone }
       it { expect(subject).not_to be_ipad }
       it { expect(subject).not_to be_universal }
@@ -54,7 +57,10 @@ describe AppInfo::IPA do
 
     after { subject.clear! }
 
-    it { expect(subject.os).to eq 'iOS' }
+    it { expect(subject.file_type).to eq AppInfo::Format::IPA }
+    it { expect(subject.file_type).to eq :ipa }
+    it { expect(subject.platform).to eq 'iOS' }
+    it { expect(subject.platform).to eq AppInfo::Platform::IOS }
     it { expect(subject).not_to be_iphone }
     it { expect(subject).to be_ipad }
     it { expect(subject).not_to be_universal }
@@ -108,7 +114,10 @@ describe AppInfo::IPA do
 
     after { subject.clear! }
 
-    it { expect(subject.os).to eq 'iOS' }
+    it { expect(subject.file_type).to eq AppInfo::Format::IPA }
+    it { expect(subject.file_type).to eq :ipa }
+    it { expect(subject.platform).to eq 'iOS' }
+    it { expect(subject.platform).to eq AppInfo::Platform::IOS }
     it { expect(subject).not_to be_iphone }
     it { expect(subject).not_to be_iphone }
     it { expect(subject).to be_universal }

--- a/spec/app_info/macos_spec.rb
+++ b/spec/app_info/macos_spec.rb
@@ -7,7 +7,10 @@ describe AppInfo::Macos do
       after { subject.clear! }
 
       context 'parse' do
-        it { expect(subject.os).to eq AppInfo::Platform::MACOS }
+        it { expect(subject.file_type).to eq AppInfo::Format::MACOS }
+        it { expect(subject.file_type).to eq :macos }
+        it { expect(subject.platform).to eq AppInfo::Platform::MACOS }
+        it { expect(subject.platform).to eq 'macOS' }
         it { expect(subject).to be_macos }
         it { expect(subject).not_to be_iphone }
         it { expect(subject).not_to be_ipad }
@@ -49,7 +52,10 @@ describe AppInfo::Macos do
       after { subject.clear! }
 
       context 'parse' do
-        it { expect(subject.os).to eq AppInfo::Platform::MACOS }
+        it { expect(subject.file_type).to eq AppInfo::Format::MACOS }
+        it { expect(subject.file_type).to eq :macos }
+        it { expect(subject.platform).to eq AppInfo::Platform::MACOS }
+        it { expect(subject.platform).to eq 'macOS' }
         it { expect(subject).to be_macos }
         it { expect(subject).not_to be_iphone }
         it { expect(subject).not_to be_ipad }

--- a/spec/app_info/mobile_provision_spec.rb
+++ b/spec/app_info/mobile_provision_spec.rb
@@ -3,6 +3,8 @@ describe AppInfo::MobileProvision do
     context 'Development' do
       subject { AppInfo::MobileProvision.new(fixture_path('mobileprovisions/ios_development.mobileprovision')) }
 
+      it { expect(subject.file_type).to eq AppInfo::Format::MOBILEPROVISION }
+      it { expect(subject.file_type).to eq :mobileprovision }
       it { expect(subject.devices).to be_a Array }
       it { expect(subject.platform).to eq :ios }
       it { expect(subject.platforms).to eq [:ios] }
@@ -27,6 +29,8 @@ describe AppInfo::MobileProvision do
     context 'Adhoc' do
       subject { AppInfo::MobileProvision.new(fixture_path('mobileprovisions/ios_adhoc.mobileprovision')) }
 
+      it { expect(subject.file_type).to eq AppInfo::Format::MOBILEPROVISION }
+      it { expect(subject.file_type).to eq :mobileprovision }
       it { expect(subject.devices).to be_a Array }
       it { expect(subject.platform).to eq :ios }
       it { expect(subject.platforms).to eq [:ios] }
@@ -51,6 +55,8 @@ describe AppInfo::MobileProvision do
     context 'AppStore' do
       subject { AppInfo::MobileProvision.new(fixture_path('mobileprovisions/ios_appstore.mobileprovision')) }
 
+      it { expect(subject.file_type).to eq AppInfo::Format::MOBILEPROVISION }
+      it { expect(subject.file_type).to eq :mobileprovision }
       it { expect(subject.devices).to be_nil }
       it { expect(subject.platform).to eq :ios }
       it { expect(subject.platforms).to eq [:ios] }
@@ -77,6 +83,8 @@ describe AppInfo::MobileProvision do
     context 'Development' do
       subject { AppInfo::MobileProvision.new(fixture_path('mobileprovisions/macos_development.provisionprofile')) }
 
+      it { expect(subject.file_type).to eq AppInfo::Format::MOBILEPROVISION }
+      it { expect(subject.file_type).to eq :mobileprovision }
       it { expect(subject.devices).to be_a Array }
       it { expect(subject.platform).to eq :macos }
       it { expect(subject.platforms).to eq [:macos] }
@@ -101,6 +109,8 @@ describe AppInfo::MobileProvision do
     context 'AppStore' do
       subject { AppInfo::MobileProvision.new(fixture_path('mobileprovisions/macos_appstore.provisionprofile')) }
 
+      it { expect(subject.file_type).to eq AppInfo::Format::MOBILEPROVISION }
+      it { expect(subject.file_type).to eq :mobileprovision }
       it { expect(subject.devices).to be_nil }
       it { expect(subject.platform).to eq :macos }
       it { expect(subject.platforms).to eq [:macos] }

--- a/spec/app_info/pe_spec.rb
+++ b/spec/app_info/pe_spec.rb
@@ -6,7 +6,10 @@ describe AppInfo::PE do
     after { subject.clear! }
 
     context 'parse' do
-      it { expect(subject.os).to eq AppInfo::Platform::WINDOWS }
+      it { expect(subject.file_type).to eq AppInfo::Format::PE }
+      it { expect(subject.file_type).to eq :pe }
+      it { expect(subject.platform).to eq AppInfo::Platform::WINDOWS }
+      it { expect(subject.platform).to eq 'Windows' }
       it { expect(subject.file).to eq file }
       it { expect(subject.binrary_file).not_to be_nil }
       it { expect(subject.size).to eq 415127 }
@@ -50,7 +53,10 @@ describe AppInfo::PE do
     after { subject.clear! }
 
     context 'parse' do
-      it { expect(subject.os).to eq AppInfo::Platform::WINDOWS }
+      it { expect(subject.file_type).to eq AppInfo::Format::PE }
+      it { expect(subject.file_type).to eq :pe }
+      it { expect(subject.platform).to eq AppInfo::Platform::WINDOWS }
+      it { expect(subject.platform).to eq 'Windows' }
       it { expect(subject.file).to eq file }
       it { expect(subject.binrary_file).not_to be_nil }
       it { expect(subject.size).to eq 293888 }

--- a/spec/app_info/proguard_spec.rb
+++ b/spec/app_info/proguard_spec.rb
@@ -7,7 +7,8 @@ describe AppInfo::Proguard do
     after { subject.clear! }
 
     context 'parse' do
-      it { expect(subject.file_type).to eq AppInfo::Platform::PROGUARD }
+      it { expect(subject.file_type).to eq AppInfo::Format::PROGUARD }
+      it { expect(subject.file_type).to eq :proguard }
       it { expect(subject.uuid).to eq '81384aeb-4837-5f73-a771-417b4399a483' }
       it { expect(subject.mapping?).to be true }
       it { expect(subject.symbol?).to be false }
@@ -27,7 +28,8 @@ describe AppInfo::Proguard do
     after { subject.clear! }
 
     context 'parse' do
-      it { expect(subject.file_type).to eq AppInfo::Platform::PROGUARD }
+      it { expect(subject.file_type).to eq AppInfo::Format::PROGUARD }
+      it { expect(subject.file_type).to eq :proguard }
       it { expect(subject.uuid).to eq '81384aeb-4837-5f73-a771-417b4399a483' }
       it { expect(subject.mapping?).to be true }
       it { expect(subject.symbol?).to be true }


### PR DESCRIPTION
## Affected parsers

- Android: apk/aab/proguard
- macOS/iOS: ipa/macos/info_pist/mobileprovision/dsym
- Windows: pe

## Methods changes

- `.os` method was abandon, use new method `.platform`.
- `.file_type` return value type from `AppInfo::Platform` to `AppInfo::Format` in `info_plist`, `proguard` parsers.